### PR TITLE
タスクリストの表示とdescの追加

### DIFF
--- a/eg/desc.pl
+++ b/eg/desc.pl
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+
+# Exports some commands
+use Cinnamon::DSL;
+
+my $application = 'My::App';
+
+# It's required if you want to login to remote host
+set user => 'johndoe';
+
+# User defined params to use later
+set application => $application;
+set repository  => "git://git.example.com/projects/$application";
+set deploy_to   => "/home/app/www/$application";
+
+# Lazily evaluated if passed as a code
+set lazy_value  => sub {
+    #...
+};
+
+# Roles
+role development => 'development.example.com';
+role test => 'test.example.com', {
+    deploy_to => "/home/app/www/$application-Test",
+    hoge      => 'fuga',
+};
+
+# Lazily evaluated if passed as a code
+role production  => sub {
+    my $res   = LWP::UserAgent->get('http://servers.example.com/api/hosts');
+    my $hosts = decode_json $res->content;
+       $hosts;
+};
+
+# Tasks
+desc 'update remote server.';
+task update => sub {
+    my ($host, @args) = @_;
+
+    # Executed on localhost
+    run 'some', 'command';
+
+    # Executed on remote host
+    remote {
+        run  'git', 'pull';
+        sudo '/path/to/httpd', 'restart';
+    } $host;
+};
+
+# nest tasks
+desc 'server nest tasks.';
+task server => {
+    setup => sub {
+        my ($host, @args) = @_;
+
+        # Executed on localhost
+        run 'some', 'command';
+
+        # Executed on remote host
+        my ($stdout, $stderr) = remote {
+            run  'git', 'pull';
+            sudo '/path/to/httpd', 'restart';
+        } $host;
+
+        # Do something with the return values
+        My::IRC::Client->new->send('#deploy', "Updated: $stdout, $stderr");
+    },
+
+    restart => sub {
+        my ($host, @args) = @_;
+        # ...
+    },
+};

--- a/lib/Cinnamon.pm
+++ b/lib/Cinnamon.pm
@@ -57,6 +57,21 @@ sub run {
     );
 }
 
+sub show_info () {
+    my ($self, %opt)  = @_;
+    my ($role, $task)  = ('','');
+    my @args = Cinnamon::Config::load $role, $task, %opt;
+
+    my @tasks = Cinnamon::Config::get_tasks;
+    my %descs = Cinnamon::Config::get_descs;
+    log success => sprintf("Tasks");
+    printf("  %-15s %s\n", $_, $descs{$_}||'') for @tasks;
+
+    my @roles = Cinnamon::Config::get_roles;
+    log success => sprintf("Roles");
+    printf("  %s\n",$_) for @roles;
+}
+
 !!1;
 
 __END__

--- a/lib/Cinnamon/CLI.pm
+++ b/lib/Cinnamon/CLI.pm
@@ -25,6 +25,7 @@ sub run {
     $p->getoptions(
         "h|help"     => \$self->{help},
         "c|config=s" => \$self->{config},
+        "T|tasks"    => \$self->{tasks},
     );
     return $self->usage if $self->{help};
 
@@ -36,6 +37,9 @@ sub run {
 
 
     my ($role, $task) = @ARGV;
+    if($self->{tasks}) {
+        return $self->cinnamon->show_info(config => $self->{config});
+    }
     unless ($role && $task) {
         $self->print("please specify role and task\n");
         return $self->usage;

--- a/lib/Cinnamon/Config.pm
+++ b/lib/Cinnamon/Config.pm
@@ -8,6 +8,7 @@ use Cinnamon::Logger;
 my %CONFIG;
 my %ROLES;
 my %TASKS;
+my %DESCS;
 
 sub set ($$) {
     my ($key, $value) = @_;
@@ -48,6 +49,11 @@ sub get_role (@) {
     return $hosts;
 }
 
+sub set_desc ($$) {
+    my ($task, $desc) = @_;
+    $DESCS{$task} = $desc;
+}
+
 sub set_task ($$) {
     my ($task, $task_def) = @_;
     $TASKS{$task} = $task_def;
@@ -83,5 +89,27 @@ sub load (@) {
 
     Cinnamon::Config::Loader->load(config => $opt{config});
 }
+
+sub get_roles () {
+    return keys %ROLES;
+}
+
+sub get_tasks () {
+    my @tasks;
+    for my $task (keys %TASKS) {
+        push @tasks, $task;
+        # nest task
+        if(ref $TASKS{$task} eq 'HASH') {
+            push @tasks, $task . ':' .$_
+                for (keys %{$TASKS{$task}});
+        }
+    }
+    return @tasks;
+}
+
+sub get_descs () {
+    return %DESCS;
+}
+
 
 !!1;

--- a/lib/Cinnamon/DSL.pm
+++ b/lib/Cinnamon/DSL.pm
@@ -14,11 +14,14 @@ our @EXPORT = qw(
     get
     role
     task
+    desc
 
     remote
     run
     sudo
 );
+
+my $cur_desc = '';
 
 sub set ($$) {
     my ($name, $value) = @_;
@@ -36,9 +39,18 @@ sub role ($$;$) {
     Cinnamon::Config::set_role $name => $hosts, $params;
 }
 
+sub desc ($) {
+    my ($desc) = @_;
+    $cur_desc = $desc;
+}
+
 sub task ($$) {
     my ($task, $task_def) = @_;
 
+    if($cur_desc) {
+        Cinnamon::Config::set_desc $task => $cur_desc;
+        $cur_desc = "";
+    }
     Cinnamon::Config::set_task $task => $task_def;
 }
 


### PR DESCRIPTION
タスク一覧を表示するようなものがないようなので書いてみました。
またDSLに「desc」を追加しタスクの説明も表示できるようにしています。

以下のように、 -T を付けるとタスクの一覧を表示します。
perl bin/cinnamon --config=eg/desc.pl -T

よろしければご検討ください。
