### PR TITLE
Modified to support more-tasks

### DIFF
--- a/lib/Cinnamon.pm
+++ b/lib/Cinnamon.pm
@@ -62,6 +62,8 @@ sub run {
         "[error]: %s",
         (join(', ', @error)   || ''),
     );
+
+    return (\@success, \@error);
 }
 
 !!1;

--- a/t/02_cli.t
+++ b/t/02_cli.t
@@ -15,7 +15,7 @@ sub setup : Test(setup) {
 sub _help : Tests {
     my $app = Test::Cinnamon::CLI::cli();
     $app->run('--help');
-    is $app->system_error, "Usage: cinnamon [--config=<path>] [--help] [--info] <role> <task>\n";
+    is $app->system_error, "Usage: cinnamon [--config=<path>] [--help] [--info] <role> <task ...>\n";
 }
 
 sub _info : Tests {
@@ -42,7 +42,7 @@ OUTPUT
 sub _no_config : Tests {
     my $app = Test::Cinnamon::CLI::cli();
     $app->run('role', 'task');
-    is $app->system_error, "cannot find config file for deploy : config/deploy.pl\nUsage: cinnamon [--config=<path>] [--help] [--info] <role> <task>\n";
+    is $app->system_error, "cannot find config file for deploy : config/deploy.pl\nUsage: cinnamon [--config=<path>] [--help] [--info] <role> <task ...>\n";
 }
 
 sub _valid : Tests {
@@ -85,6 +85,63 @@ task args => sub {
 CONFIG
     $app->run('test', 'args', '-s', 'args1=foo', '-s', 'args2=bar');
     like $app->system_output, qr{foo\tbar};
+}
+
+sub _more_tasks : Tests {
+    my $app = Test::Cinnamon::CLI::cli();
+    $app->dir->touch("config/deploy.pl", <<CONFIG);
+use Cinnamon::DSL;
+set user       => 'app';
+set deploy_to  => '/home/app/deploy_to';
+role test => 'localhost';
+task echo_user => sub {
+    print(get 'user');
+};
+task echo_deploy_to => sub {
+    print(get 'deploy_to');
+};
+CONFIG
+    my $exit_status = $app->run('test', 'echo_user', 'echo_deploy_to');
+    like $app->system_output, qr{app};
+    like $app->system_output, qr{deploy_to};
+}
+
+sub _fail_at_more_tasks : Tests {
+    my $app = Test::Cinnamon::CLI::cli();
+    $app->dir->touch("config/deploy.pl", <<CONFIG);
+use Cinnamon::DSL;
+set user       => 'app';
+set deploy_to  => '/home/app/deploy_to';
+role test => 'localhost';
+task die_user => sub {
+    die get 'user';
+};
+task echo_deploy_to => sub {
+    print(get 'deploy_to');
+};
+CONFIG
+    my $exit_status = $app->run('test', 'die_user', 'echo_deploy_to');
+    like $app->system_error, qr{app};
+    unlike $app->system_output, qr{deploy_to};
+}
+
+sub _fail_at_more_tasks_with_ignore_errors_option : Tests {
+    my $app = Test::Cinnamon::CLI::cli();
+    $app->dir->touch("config/deploy.pl", <<CONFIG);
+use Cinnamon::DSL;
+set user       => 'app';
+set deploy_to  => '/home/app/deploy_to';
+role test => 'localhost';
+task die_user => sub {
+    die get 'user';
+};
+task echo_deploy_to => sub {
+    print(get 'deploy_to');
+};
+CONFIG
+    my $exit_status = $app->run('--ignore-errors', 'test', 'die_user', 'echo_deploy_to');
+    like $app->system_error, qr{app};
+    like $app->system_output, qr{deploy_to};
 }
 
 __PACKAGE__->runtests;


### PR DESCRIPTION
コマンドラインで複数のタスクを指定できるように修正してみました。

デフォルトの動作では、タスクにエラーがあった場合はそこで終了し、後続のタスクは実行されません。
--ignore-erros(-I)オプションを指定することで、タスクにエラーがあった場合でも後続のタスクが実行されます。

よろしければご検討ください。
