### PR TITLE
Modified to return success/failure in Cinnamon::CLI#run

### DIFF
--- a/bin/cinnamon
+++ b/bin/cinnamon
@@ -3,5 +3,6 @@ use strict;
 use warnings;
 use Cinnamon;
 use Cinnamon::CLI;
-
-Cinnamon::CLI->new->run(@ARGV);
+use POSIX qw/:stdlib_h/;
+my $exit_status = ( Cinnamon::CLI->new->run(@ARGV) ) ? EXIT_SUCCESS : EXIT_FAILURE;
+exit $exit_status;

--- a/t/lib/Test/Cinnamon/CLI.pm
+++ b/t/lib/Test/Cinnamon/CLI.pm
@@ -37,9 +37,11 @@ sub dir {
 
 sub run {
     my ($self, @args) = @_;
+    my $success;
     ($self->{system_output}, $self->{system_error}) = capture {
-        Cinnamon::CLI->new->run(@args);
+        $success = Cinnamon::CLI->new->run(@args);
     };
+    return $success;
 }
 
 sub system_output {


### PR DESCRIPTION
Cinnamon::CLI#run で、成功/失敗を返すように修正しました。
あわせて bin/cinnamon で終了ステータスを返すように修正しました。

bin/cinnamon の実行結果で他のコマンドと連携したかったのがきっかけです。

```
# e.g.
% cinnamon role task && notify-send "success"
```

よろしければご検討ください。
