### PR TITLE
Fixed the deletion of tempdir in test

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -29,6 +29,7 @@ my $build = Module::Build->new(
     },
     build_requires       => {
         'Directory::Scratch' => 0,
+        'Cwd::Guard'         => 0,
         'Capture::Tiny'      => 0,
         'Test::More'         => 0.98,
         'Test::Class'        => 0,

--- a/t/lib/Test/Cinnamon/CLI.pm
+++ b/t/lib/Test/Cinnamon/CLI.pm
@@ -4,16 +4,17 @@ use warnings;
 
 our @EXPORT = qw(cli);
 
-use Test::Requires qw(Directory::Scratch);
+use Test::Requires qw(Directory::Scratch Cwd::Guard);
 
 use Cinnamon::CLI;
 
 sub cli {
     my $dir = Directory::Scratch->new();
-    chdir $dir;
+    my $guard = Cwd::Guard::cwd_guard $dir;
     $dir->mkdir('config');
 
     my $app = Test::Cinnamon::CLI::App->new(dir => $dir);
+    $app->{_cwd_guard} = $guard;
     return $app;
 }
 


### PR DESCRIPTION
t/02_cli.t 終了時にカレントディレクトリがテンポラリディレクトリのため、unlinkで失敗する警告がでていたのですが、これを修正してみました。

ひょっとしたら私の環境だけかもしれませんが、よろしければ修正をご検討ください。
