### PR TITLE
Cinnamon::Remote に tty オプションが渡るように

### DIFF
--- a/lib/Cinnamon/DSL.pm
+++ b/lib/Cinnamon/DSL.pm
@@ -93,7 +93,8 @@ sub sudo (@) {
         print "\n";
     }
 
-    run {sudo => 1, password => $password}, @cmd;
+    my $tty = Cinnamon::Config::get('tty');
+    run {sudo => 1, password => $password, tty => $tty}, @cmd;
 }
 
 !!1;

--- a/t/01_remote.t
+++ b/t/01_remote.t
@@ -54,4 +54,17 @@ subtest 'sudo run success' => sub {
     ok !$res->{has_error};
 };
 
+subtest 'sudo run with tty' => sub {
+    local *Net::OpenSSH::capture2 = sub {
+        my ($self, $opt, $cmd) = @_;
+        return ($cmd, $opt);
+    };
+    my $remote = Cinnamon::Remote->new(host => 'localhost', user => 'app');
+    $remote->connection->error('error');
+    my $res = $remote->execute({sudo => 1, password => 'password', tty => 1}, "ls", "/");
+    is $res->{stdout}, "sudo -Sk ls /";
+    is $res->{stderr}->{stdin_data}, "password\n";
+    ok !$res->{has_error};
+};
+
 done_testing();


### PR DESCRIPTION
Cinnamon::Remote が以下のように実装されているのですが、$opt->{tty} はどこでも設定されていないため、常に undef となっていたのを修正してみました。

``` perl
    # at Cinnamon::Remote line 34
    my ($stdin, $stdout, $stderr, $pid) = $conn->open3({
        tty => $opt->{tty},  # <-- value $opt->{tty} is always undef
    }, join ' ', @cmd);
```

よろしくお願いいたします。
