### PR TITLE
カラー出力を制限したい

### DIFF
--- a/lib/Cinnamon/CLI.pm
+++ b/lib/Cinnamon/CLI.pm
@@ -4,6 +4,7 @@ use warnings;
 
 use Getopt::Long;
 use Cinnamon;
+use Cinnamon::Logger;
 
 use constant { SUCCESS => 0, ERROR => 1 };
 
@@ -14,7 +15,10 @@ sub new {
 
 sub cinnamon {
     my $self = shift;
-    $self->{cinnamon} ||= Cinnamon->new;
+    $self->{cinnamon} ||= do {
+        $Cinnamon::Logger::OUTPUT_COLOR = !$self->{no_color};
+        Cinnamon->new;
+    };
 }
 
 sub run {
@@ -25,11 +29,12 @@ sub run {
         config => ["no_ignore_case", "pass_through"],
     );
     $p->getoptions(
-        "h|help"     => \$self->{help},
-        "i|info"     => \$self->{info},
-        "c|config=s" => \$self->{config},
-        "s|set=s%"   => \$self->{override_settings},
+        "h|help"          => \$self->{help},
+        "i|info"          => \$self->{info},
+        "c|config=s"      => \$self->{config},
+        "s|set=s%"        => \$self->{override_settings},
         "I|ignore-errors" => \$self->{ignore_errors},
+        "no-color"        => \$self->{no_color},
     );
 
     # --help option

--- a/lib/Cinnamon/Logger.pm
+++ b/lib/Cinnamon/Logger.pm
@@ -11,6 +11,8 @@ our @EXPORT = qw(
     log
 );
 
+our $OUTPUT_COLOR = 1;
+
 my %COLOR = (
     success => 'green',
     error   => 'red',
@@ -19,7 +21,7 @@ my %COLOR = (
 
 sub log ($$) {
     my ($type, $message) = @_;
-    my $color ||= $COLOR{$type};
+    my $color = !!$OUTPUT_COLOR ? $COLOR{$type} : 0;
 
     $message = Term::ANSIColor::colored $message, $color if $color;
     $message .= "\n";

--- a/t/02_cli.t
+++ b/t/02_cli.t
@@ -157,4 +157,22 @@ CONFIG
     like $app->system_output, qr{deploy_to};
 }
 
+sub _specifies_colorized_output : Tests {
+    require Term::ANSIColor;
+    my $app = Test::Cinnamon::CLI::cli();
+    $app->dir->touch("config/deploy.pl", <<CONFIG);
+use Cinnamon::DSL;
+role colorful   => 'localhost';
+task echo_color => sub { printf 'color me surprised' };
+CONFIG
+
+    my $output = '[error]: ';
+    my $color  = Term::ANSIColor::colored($output, 'red');
+    is $app->run('colorful', 'echo_color'), CLI_SUCCESS;
+    is $app->system_error, $color . "\n";
+
+    is $app->run('--no-color', 'colorful', 'echo_color'), CLI_SUCCESS;
+    is $app->system_error, $output . "\n";
+}
+
 __PACKAGE__->runtests;


### PR DESCRIPTION
出力をリダイレクトしたり、cron などで実行したりした場合に、カラー出力のエスケープシーケンスが邪魔な場合があるため、色出力の要否を設定したいなと思い試しに実装してみました。

たとえば `$ENV{CINNAMON_COLORS}` で制御するなど、方法は他にもあると思いますが基本方針としていかがでしょうか。
ご意見お聞かせください。
