### PR TITLE
[ご提案] Cinnamon::Localでsudoと非同期の出力を行えるように修正しました

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -26,6 +26,7 @@ my $build = Module::Build->new(
         'AnyEvent'        => 0,
         'POSIX'           => 0,
         'YAML'            => 0,
+        'String::ShellQuote' => 0,
     },
     build_requires       => {
         'Directory::Scratch' => 0,
@@ -34,6 +35,8 @@ my $build = Module::Build->new(
         'Test::More'         => 0.98,
         'Test::Class'        => 0,
         'Test::Requires'     => 0,
+        'Test::SharedFork'   => 0,
+        'Test::Flatten'      => 0,
     },
 
     no_index    => { 'directory' => [ 'inc' ] },

--- a/eg/test.pl
+++ b/eg/test.pl
@@ -1,0 +1,78 @@
+use strict;
+use warnings;
+
+use Cinnamon::DSL;
+
+set user     => 'myuser';
+set password => 'mypassword';
+
+role test => 'localhost';
+
+# Tasks
+task local => {
+    simple => sub {
+        run 'echo -n STDOUT && echo -n hoge';
+        run 'echo STDOUT && echo foo';
+        run qw{ echo -n STDOUT };
+        run qw{ echo STDOUT };
+        run qw{ /bin/sh -c }, 'echo -n STDERR >&2';
+        run qw{ /bin/sh -c }, 'echo STDERR >&2';
+
+        run 'for i in $(seq 1 5); do date; sleep 1; done';
+        run 'for i in $(seq 1 5); do echo -n $i; sleep 1; done';
+        run 'for i in $(seq 1 5); do echo $i 1>&2; sleep 1; done';
+
+    },
+    sudo => sub {
+        sudo 'echo -n STDOUT';
+        sudo 'echo STDOUT';
+        sudo qw{ echo -n STDOUT };
+        sudo qw{ echo STDOUT };
+        sudo qw{ /bin/sh -c }, 'echo -n STDERR >&2';
+        sudo qw{ /bin/sh -c }, 'echo STDERR >&2';
+
+        sudo 'for i in $(seq 1 5); do date; sleep 1; done';
+        sudo 'for i in $(seq 1 5); do echo -n $i; sleep 1; done';
+        sudo 'for i in $(seq 1 5); do echo $i 1>&2; sleep 1; done';
+    },
+    fail_simple => sub {
+        run 'non_existing_command';
+    },
+    fail_sudo => sub {
+        sudo 'non_existing_command';
+    },
+};
+
+task remote => {
+    simple => sub {
+        my ($host, @args) = @_;
+        remote {
+            run 'echo -n STDOUT && echo -n hoge';
+            run 'echo STDOUT && echo foo';
+            run qw{ echo -n STDOUT };
+            run qw{ echo STDOUT };
+            run qw{ /bin/sh -c }, 'echo -n STDERR >&2';
+            run qw{ /bin/sh -c }, 'echo STDERR >&2';
+
+            run 'for i in $(seq 1 5); do date; sleep 1; done';
+            run 'for i in $(seq 1 5); do echo -n $i; sleep 1; done';
+            run 'for i in $(seq 1 5); do echo $i 1>&2; sleep 1; done';
+        } $host;
+
+    },
+    sudo => sub {
+        my ($host, @args) = @_;
+        remote {
+            sudo 'echo -n STDOUT';
+            sudo 'echo STDOUT';
+            sudo qw{ echo -n STDOUT };
+            sudo qw{ echo STDOUT };
+            sudo qw{ /bin/sh -c }, 'echo -n STDERR >&2';
+            sudo qw{ /bin/sh -c }, 'echo STDERR >&2';
+
+            sudo 'for i in $(seq 1 5); do date; sleep 1; done';
+            sudo 'for i in $(seq 1 5); do echo -n $i; sleep 1; done';
+            sudo 'for i in $(seq 1 5); do echo $i 1>&2; sleep 1; done';
+        } $host;
+    },
+};

--- a/lib/Cinnamon/CommandBuilder.pm
+++ b/lib/Cinnamon/CommandBuilder.pm
@@ -1,0 +1,47 @@
+package Cinnamon::CommandBuilder;
+use strict;
+use warnings;
+
+use String::ShellQuote;
+
+use constant {
+    SHELL_DEFAULT       => [qw{ /bin/bash -l -c }],
+    SUDO                => 'sudo',
+    SUDO_OPT_USER       => '-u',
+    SUDO_OPT_GROUP      => '-g',
+    SUDO_DEFAULT_OPTS   => ['-Sk'],
+    SUDO_ARGS_INDICATOR => '--',
+};
+
+sub new {
+    my $class = shift;
+    my $args = {
+        shell      => [ @{ SHELL_DEFAULT() } ],
+        sudo       => 0,
+        sudo_opts  => [ @{ SUDO_DEFAULT_OPTS() } ],
+        sudo_user  => undef,
+        sudo_group => undef,
+        @_,
+    };
+    bless $args, $class;
+};
+
+sub build {
+    my ($self, @cmd) = @_;
+
+    if (@cmd == 1) {
+        @cmd = (@{ $self->{shell} }, $cmd[0]);
+    }
+    if ( $self->{sudo} ) {
+        my @sudo_opts = @{ $self->{sudo_opts} || [] };
+        push( @sudo_opts, SUDO_OPT_USER, $self->{sudo_user} )
+            if ( $self->{sudo_user} );
+        push( @sudo_opts, SUDO_OPT_GROUP, $self->{sudo_group} )
+            if ( $self->{sudo_group} );
+        unshift @cmd, SUDO, @sudo_opts, SUDO_ARGS_INDICATOR;
+    }
+
+    wantarray ? @cmd : shell_quote(@cmd);
+}
+
+!!1;

--- a/lib/Cinnamon/CommandExecutor.pm
+++ b/lib/Cinnamon/CommandExecutor.pm
@@ -1,0 +1,40 @@
+package Cinnamon::CommandExecutor;
+use strict;
+use warnings;
+use Carp ();
+
+use Cinnamon::CommandBuilder;
+use Cinnamon::HandleManager;
+
+sub new {
+    my ($class, %args) = @_;
+    Carp::croak __PACKAGE__ . " can't be instantiated" if ($class eq __PACKAGE__);
+    bless \%args, $class;
+}
+
+sub host     { Carp::croak "host() is not implemented" }
+sub _execute { Carp::croak "actually_execute() is not implemented" }
+
+sub execute {
+    my ($self, $opt, @cmd) = @_;
+    $opt ||= {};
+
+    my $builder = Cinnamon::CommandBuilder->new(%$opt);
+    if (defined $opt->{password}) {
+        push @{ $builder->{sudo_opts} }, '-p', '';
+    }
+    @cmd = $builder->build(@cmd);
+
+    my $hm = Cinnamon::HandleManager->new(host => $self->host);
+    my ( $stdout, $stderr, $exitcode )
+        = $hm->handle( sub { $self->_execute( $opt, @cmd ) } );
+
+    +{
+        stdout    => $stdout,
+        stderr    => $stderr,
+        has_error => $exitcode > 0,
+        error     => $exitcode,
+    };
+}
+
+!!1;

--- a/lib/Cinnamon/DSL.pm
+++ b/lib/Cinnamon/DSL.pm
@@ -7,6 +7,7 @@ use Cinnamon::Config;
 use Cinnamon::Local;
 use Cinnamon::Remote;
 use Cinnamon::Logger;
+use Cinnamon::CommandBuilder;
 use Term::ReadKey;
 
 our @EXPORT = qw(
@@ -59,13 +60,13 @@ sub remote (&$) {
 
 sub run (@) {
     my (@cmd) = @_;
-    my $opt;
-    $opt = shift @cmd if ref $cmd[0] eq 'HASH';
+    my $opt = (ref $cmd[0] eq 'HASH') ? shift @cmd : {};
 
     my ($stdout, $stderr);
     my $result;
 
-    log info => sprintf "[%s :: executing] %s", _host(), join(' ', @cmd);
+    my $cmd_str = Cinnamon::CommandBuilder->new(%$opt)->build(@cmd);
+    log info => sprintf "[%s :: executing] %s", _host(), $cmd_str;
 
     if ($opt && $opt->{sudo}) {
         my $password = Cinnamon::Config::get('password');
@@ -100,6 +101,6 @@ sub _sudo_password {
 }
 
 sub _host    { 'localhost' }
-sub _execute { Cinnamon::Local->execute(@_) }
+sub _execute { Cinnamon::Local->new->execute(@_) }
 
 !!1;

--- a/lib/Cinnamon/HandleManager.pm
+++ b/lib/Cinnamon/HandleManager.pm
@@ -9,17 +9,21 @@ use AnyEvent::Handle;
 
 use POSIX;
 
+# HOST(%1$s), NAME(%2$s), MESSAGE(%3$s)
+use constant OUTPUT_FORMAT => "[%s :: %s] %s";
+
 sub new {
     my ($class, %args) = @_;
     bless \%args, $class;
 }
 
 sub register_fh {
-    my ($self, $name, $fh) = @_;
+    my ($self, $name, $fh, $format) = @_;
     my $handle_container = $self->{handle_container} ||= {};
     $handle_container->{$name} = {
         fh => $fh,
         output_lines => [],
+        format => $format || OUTPUT_FORMAT,
     };
 }
 
@@ -39,7 +43,7 @@ sub start_async_read {
                 $handle->push_read(line => sub {
                     my $line = $_[1];
                     push @{$info->{output_lines}}, $line;
-                    log info => sprintf "[%s :: %s] %s",
+                    log info => sprintf $info->{format},
                         $self->{host}, $name, $line;
                 });
             },
@@ -47,8 +51,13 @@ sub start_async_read {
                 $cv->end;
             },
             on_error => sub {
+                if (my $buf_remain = $handle->rbuf) {
+                    push @{$info->{output_lines}}, $buf_remain;
+                    log info => sprintf $info->{format},
+                        $self->{host}, $name, $buf_remain;
+                }
                 my $msg = $_[2];
-                log error => sprintf "[%s :: %s] %s", $self->{host}, $name, $msg
+                log error => sprintf $info->{format}, $self->{host}, $name, $msg
                     unless $! == POSIX::EPIPE;
                 $cv->end;
             },
@@ -68,6 +77,61 @@ sub captured_str {
     my $hinfo = $self->{handle_container}->{$name} or return '';
     my $str = join("\n", @{$hinfo->{output_lines}});
     return $str;
+}
+
+sub handle {
+    my ( $self, $code, $format ) = @_;
+    my ( $rout, $wout ) = mkpipe();
+    my ( $rerr, $werr ) = mkpipe();
+
+    my $pid = fork;
+    Carp::croak "Can't fork: $!" unless ( defined $pid );
+
+    unless ($pid) { # child
+        close $rout;
+        close $rerr;
+
+        my $old = select;
+        close STDOUT; open STDOUT, '>&', $wout; select STDOUT; $| = 1;
+        close STDERR; open STDERR, '>&', $werr; select STDERR; $| = 1;
+        select $old;
+
+        close $wout;
+        close $werr;
+
+        eval { $code->() };
+
+        ($@) ? exit(1) : exit(0);
+    }
+
+    close $wout;
+    close $werr;
+
+    $self->register_fh(stdout => $rout, $format);
+    $self->register_fh(stderr => $rerr, $format);
+    $self->start_async_read();
+
+    local $? = 0;
+    waitpid( $pid, 0 );
+    my $exitcode = $? >> 8;
+
+    my $stdout = $self->captured_str('stdout');
+    my $stderr = $self->captured_str('stderr');
+
+    return ($stdout, $stderr, $exitcode);
+}
+
+use Symbol;
+sub mkpipe {
+    my ( $r, $w );
+    $r = Symbol::gensym();
+    $w = Symbol::gensym();
+    pipe $r, $w or Carp::croak "can't open pipe";
+    my $old = select;
+    select $r; $| = 1;
+    select $w; $| = 1;
+    select $old;
+    return ( $r, $w );
 }
 
 1;

--- a/lib/Cinnamon/Local.pm
+++ b/lib/Cinnamon/Local.pm
@@ -4,28 +4,19 @@ use warnings;
 use Carp ();
 use IPC::Run ();
 
-use Cinnamon::Logger;
+use base qw/Cinnamon::CommandExecutor/;
 
-sub execute {
-    my ($class, $opt, @cmd) = @_;
-    my $result = IPC::Run::run \@cmd, \my $stdin, \my $stdout, \my $stderr;
-    chomp for ($stdout, $stderr);
+sub host { 'localhost' }
 
-    for my $line (split "\n", $stdout) {
-        log info => sprintf "[localhost :: stdout] %s",
-            $line;
-    }
-    for my $line (split "\n", $stderr) {
-        log info => sprintf "[localhost :: stderr] %s",
-            $line;
+sub _execute {
+    my ($self, $opt, @cmd) = @_;
+
+    my $stdin_str;
+    if (defined $opt->{password}) {
+        $stdin_str = "$opt->{password}\n";
     }
 
-    +{
-        stdout    => $stdout,
-        stderr    => $stderr,
-        has_error => !$result,
-        error     => $?,
-    };
+    IPC::Run::run \@cmd, \$stdin_str or die;
 }
 
 !!1;

--- a/lib/Cinnamon/Logger.pm
+++ b/lib/Cinnamon/Logger.pm
@@ -5,8 +5,6 @@ use parent qw(Exporter);
 
 use Term::ANSIColor ();
 
-use Cinnamon::Config;
-
 our @EXPORT = qw(
     log
 );

--- a/lib/Cinnamon/Remote.pm
+++ b/lib/Cinnamon/Remote.pm
@@ -3,13 +3,7 @@ use strict;
 use warnings;
 use Net::OpenSSH;
 
-use Cinnamon::HandleManager;
-use Cinnamon::Logger;
-
-sub new {
-    my ($class, %args) = @_;
-    bless \%args, $class;
-}
+use base qw/Cinnamon::CommandExecutor/;
 
 sub connection {
     my $self = shift;
@@ -18,44 +12,20 @@ sub connection {
     );
 }
 
-sub host { $_[0]->{host} }
+sub host { $_[0]->{host} || '' }
 
-sub execute {
+sub _execute {
     my ($self, $opt, @cmd) = @_;
-    my $host = $self->host || '';
-    my $conn = $self->connection;
-    my $exec_opt = {};
 
-    if (defined $opt && $opt->{sudo}) {
-        @cmd = ('sudo', '-Sk', @cmd);
+    my $stdin_str;
+    if (defined $opt->{password}) {
+        $stdin_str = "$opt->{password}\n";
     }
 
-    my ($stdin, $stdout, $stderr, $pid) = $conn->open3({
-        tty => $opt->{tty},
-    }, join ' ', @cmd);
-
-    if ($opt->{password}) {
-        print $stdin "$opt->{password}\n";
-    }
-
-    my $hm = Cinnamon::HandleManager->new(host => $self->{host});
-    $hm->register_fh(stdout => $stdout);
-    $hm->register_fh(stderr => $stderr);
-    $hm->start_async_read();
-
-    my $stdout_str = $hm->captured_str('stdout');
-    my $stderr_str = $hm->captured_str('stderr');
-
-    local $? = 0;
-    waitpid($pid, 0);
-    my $exitcode = $?;
-
-    +{
-        stdout    => $stdout_str,
-        stderr    => $stderr_str,
-        has_error => $exitcode > 0,
-        error     => $exitcode,
-    };
+    $self->connection->system(
+        { stdin_data => $stdin_str, tty => $opt->{tty} },
+        @cmd,
+    ) or die;
 }
 
 sub DESTROY {

--- a/t/01_local.t
+++ b/t/01_local.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+use Path::Class;
+use lib file(__FILE__)->dir->file('lib')->stringify;
+
+use constant { EXIT_SUCCESS => 0, EXIT_ERROR => 1 };
+
+use Cinnamon::Local;
+use Cinnamon::CommandBuilder;
+
+no strict 'refs';
+no warnings 'redefine';
+
+sub mock_ipc_run {
+    my $opts = {
+        error               => 0,
+        check_stdin_handler => sub { },
+        @_,
+    };
+    return sub {
+        my ( $cmd, $stdin ) = @_;
+        $opts->{check_stdin_handler}->($$stdin);
+        my $cmd_str = _cmd_str(@$cmd) . "\n";
+        print $cmd_str;
+        print STDERR $cmd_str;
+        return !$opts->{error};
+    };
+}
+
+sub _cmd_str {
+    my @cmd = @_;
+    join ' ', map { "'$_'" } @cmd;
+}
+
+subtest 'run success' => sub {
+    local *IPC::Run::run = mock_ipc_run();
+    my $local = Cinnamon::Local->new();
+    my @cmd = qw{ ls / };
+    my $res = $local->execute(undef, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new();
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
+    ok !$res->{has_error};
+    is $res->{error}, EXIT_SUCCESS;
+};
+
+subtest 'run failure' => sub {
+    local *IPC::Run::run = mock_ipc_run(error => 1);
+    my $local = Cinnamon::Local->new();
+    my @cmd = qw{ ls / };
+    my $res = $local->execute(undef, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new();
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
+    ok $res->{has_error};
+    is $res->{error}, EXIT_ERROR;
+};
+
+subtest 'sudo run success' => sub {
+    my $password = 'password';
+    local *IPC::Run::run = mock_ipc_run(
+        check_stdin_handler => sub {
+            is $_[0], "$password\n";
+        },
+    );
+    my $remote = Cinnamon::Local->new();
+    my @cmd = qw{ ls / };
+    my $res = $remote->execute({sudo => 1, password => $password}, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new(sudo => 1);
+    push @{ $cb->{sudo_opts} }, '-p', '';
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
+    ok !$res->{has_error};
+    is $res->{error}, EXIT_SUCCESS;
+};
+
+done_testing();

--- a/t/01_remote.t
+++ b/t/01_remote.t
@@ -1,70 +1,112 @@
 use strict;
 use warnings;
-use Test::More skip_all => 'TODO';
+use Test::More;
+use Path::Class;
+use lib file(__FILE__)->dir->file('lib')->stringify;
+
+use constant { EXIT_SUCCESS => 0, EXIT_ERROR => 1 };
 
 use Net::OpenSSH;
-
 use Cinnamon::Remote;
+use Cinnamon::CommandBuilder;
 
 no strict 'refs';
 no warnings 'redefine';
+
 local *Net::OpenSSH::new = sub {
     my ($class, $host, %args) = @_;
     bless {}, $class;
 };
 
-subtest 'run success' => sub {
-    local *Net::OpenSSH::capture2 = sub {
-        my ($self, $cmd) = @_;
-        return ($cmd, $cmd);
+sub mock_openssh_system {
+    my $opts = {
+        error               => 0,
+        check_stdin_handler => sub { },
+        check_opt_handler   => sub { },
+        @_,
     };
+    return sub {
+        my ( $self, $opt, @cmd ) = @_;
+        my $stdin = $opt->{stdin_data};
+        $opts->{check_stdin_handler}->($stdin);
+        $opts->{check_opt_handler}->($opt);
+        my $cmd_str = _cmd_str(@cmd) . "\n";
+        print $cmd_str;
+        print STDERR $cmd_str;
+        return !$opts->{error};
+    };
+}
+
+sub _cmd_str {
+    my @cmd = @_;
+    join ' ', map { "'$_'" } @cmd;
+}
+
+subtest 'run success' => sub {
+    local *Net::OpenSSH::system = mock_openssh_system();
     my $remote = Cinnamon::Remote->new(host => 'localhost', user => 'app');
-    my $res = $remote->execute({}, "ls", "/");
-    is $res->{stdout}, "ls /";
-    is $res->{stderr}, "ls /";
+    my @cmd = qw{ ls / };
+    my $res = $remote->execute(undef, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new();
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
     ok !$res->{has_error};
-    is $res->{error}, undef;
+    is $res->{error}, EXIT_SUCCESS;
 };
 
 subtest 'run failure' => sub {
-    local *Net::OpenSSH::capture2 = sub {
-        my ($self, $cmd) = @_;
-        return ($cmd, $cmd);
-    };
-    local *Net::OpenSSH::error = sub { 'error' };
+    local *Net::OpenSSH::system = mock_openssh_system(error => 1);
     my $remote = Cinnamon::Remote->new(host => 'localhost', user => 'app');
-    $remote->connection->error('error');
-    my $res = $remote->execute({}, "ls", "/");
-    is $res->{stdout}, "ls /";
-    is $res->{stderr}, "ls /";
+    my @cmd = qw{ ls / };
+    my $res = $remote->execute(undef, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new();
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
     ok $res->{has_error};
-    is $res->{error}, 'error';
+    is $res->{error}, EXIT_ERROR;
 };
 
 subtest 'sudo run success' => sub {
-    local *Net::OpenSSH::capture2 = sub {
-        my ($self, $opt, $cmd) = @_;
-        return ($cmd, $opt);
-    };
+    my $password = 'password';
+    local *Net::OpenSSH::system = mock_openssh_system(
+        check_stdin_handler => sub {
+            is $_[0], "$password\n";
+        },
+    );
     my $remote = Cinnamon::Remote->new(host => 'localhost', user => 'app');
-    $remote->connection->error('error');
-    my $res = $remote->execute({sudo => 1, password => 'password'}, "ls", "/");
-    is $res->{stdout}, "sudo -Sk ls /";
-    is $res->{stderr}->{stdin_data}, "password\n";
+    my @cmd = qw{ ls / };
+    my $res = $remote->execute({sudo => 1, password => $password}, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new(sudo => 1);
+    push @{ $cb->{sudo_opts} }, '-p', '';
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
     ok !$res->{has_error};
+    is $res->{error}, EXIT_SUCCESS;
 };
 
 subtest 'sudo run with tty' => sub {
-    local *Net::OpenSSH::capture2 = sub {
-        my ($self, $opt, $cmd) = @_;
-        return ($cmd, $opt);
-    };
+    my $password = 'password';
+    local *Net::OpenSSH::system = mock_openssh_system(
+        check_stdin_handler => sub {
+            is $_[0], "$password\n";
+        },
+        check_opt_handler => sub {
+            ok shift->{tty};
+        }
+    );
     my $remote = Cinnamon::Remote->new(host => 'localhost', user => 'app');
-    $remote->connection->error('error');
-    my $res = $remote->execute({sudo => 1, password => 'password', tty => 1}, "ls", "/");
-    is $res->{stdout}, "sudo -Sk ls /";
-    is $res->{stderr}->{stdin_data}, "password\n";
+    my @cmd = qw{ ls / };
+    my $res = $remote->execute({sudo => 1, password => $password, tty => 1}, @cmd);
+    my $cb = Cinnamon::CommandBuilder->new(sudo => 1);
+    push @{ $cb->{sudo_opts} }, '-p', '';
+    my $cmd_str = _cmd_str($cb->build(@cmd));
+    is $res->{stdout}, $cmd_str;
+    is $res->{stderr}, $cmd_str;
     ok !$res->{has_error};
+    is $res->{error}, EXIT_SUCCESS;
 };
 
 done_testing();

--- a/t/04_commandbuilder.t
+++ b/t/04_commandbuilder.t
@@ -1,0 +1,78 @@
+use strict;
+use warnings;
+use Test::More;
+use Path::Class;
+
+use base qw(Test::Class);
+
+use Cinnamon::CommandBuilder;
+
+sub _build : Tests {
+    subtest default => sub {
+        my @command = qw{ls -la --color=never};
+        my $c = Cinnamon::CommandBuilder->new;
+        is_deeply [ $c->build(@command) ],
+            [ 'ls', '-la', '--color=never' ];
+        is_deeply [ $c->build( join ' ', @command ) ],
+            [ '/bin/bash', '-l', '-c', 'ls -la --color=never' ];
+    };
+
+    subtest 'shell_exec' => sub {
+        my @command = qw{ls -la --color=never};
+        subtest 'no_shell' => sub {
+            my $c = Cinnamon::CommandBuilder->new( shell => [] );
+            is_deeply [ $c->build(@command) ],
+                [ 'ls',  '-la', '--color=never' ];
+            is_deeply [ $c->build(join ' ', @command) ],
+                [ 'ls -la --color=never' ];
+        };
+
+        subtest 'change_shell' => sub {
+            my $c = Cinnamon::CommandBuilder->new( shell => [qw{/bin/sh -c}] );
+            is_deeply [ $c->build(@command) ],
+                [ 'ls',  '-la', '--color=never' ];
+            is_deeply [ $c->build(join ' ', @command) ],
+                [ '/bin/sh', '-c', 'ls -la --color=never' ];
+         }
+    };
+
+    subtest sudo => sub {
+        my @command = qw{ls -la --color=never /root};
+        my $c = Cinnamon::CommandBuilder->new( sudo => 1 );
+        is_deeply [ $c->build(@command) ],
+            [ 'sudo', '-Sk', '--',  'ls', '-la', '--color=never', '/root' ];
+        is_deeply [ $c->build(join ' ', @command) ],
+            [ 'sudo', '-Sk', '--', '/bin/bash', '-l', '-c', 'ls -la --color=never /root' ];
+    };
+
+    subtest 'no_sudo_opts' => sub {
+        my @command = qw{ls -la --color=never /root};
+        my $c = Cinnamon::CommandBuilder->new( sudo => 1, sudo_opts => [] );
+        is_deeply [ $c->build(@command) ],
+            [ 'sudo', '--',  'ls', '-la', '--color=never', '/root' ];
+        is_deeply [ $c->build(join ' ', @command) ],
+            [ 'sudo', '--', '/bin/bash', '-l', '-c', 'ls -la --color=never /root' ];
+    };
+
+    subtest 'user/group' => sub {
+        my @command = qw{ls -la --color=never /root};
+        my $c = Cinnamon::CommandBuilder->new( sudo => 1, sudo_user => 'app', sudo_group => 'www' );
+        is_deeply [ $c->build(@command) ],
+            [ 'sudo', '-Sk', '-u', 'app', '-g', 'www', '--',  'ls', '-la', '--color=never', '/root' ];
+        is_deeply [ $c->build(join ' ', @command) ],
+            [ 'sudo', '-Sk', '-u', 'app', '-g', 'www', '--', '/bin/bash', '-l', '-c', 'ls -la --color=never /root' ];
+    };
+
+    subtest 'has_control_operator' => sub {
+        my @command = qw{ls -la --color=never && whoami};
+        my $c = Cinnamon::CommandBuilder->new;
+        is_deeply [ $c->build(@command) ],
+            [ 'ls', '-la', '--color=never', '&&', 'whoami' ],
+            "'&&' is not interpreted as control operator";
+        is_deeply [ $c->build( join ' ', @command ) ],
+            [ '/bin/bash', '-l', '-c', 'ls -la --color=never && whoami' ];
+    };
+}
+
+__PACKAGE__->runtests;
+


### PR DESCRIPTION
Cinnamon::Localでsudoと非同期の出力を行えるように修正しました。

この修正で実装をまとめるべき箇所が挙がってきたので、下記の修正も行いました。  
修正箇所が多く、ポリシーにそぐわないところもあると思われるので、マージの要望というよりもご提案とさせて頂きます。
- 実行コマンドを構成するための Cinnamon::CommandBuilder を追加
- Cinnamon::HandleManager に handle() と mkpipe() を追加。handle() は引数のサブルーチンリファレンスを子プロセスで実行し、そのSTDIN/STDERRをハンドルします。 
- Cinnamon::Local と Cinnamon::Remote のスーパークラスとして Cinnamon::CommandExecutor を追加。実行のインターフェースを統一。
- 先の追加にあわせて Cinnamon::Local と Cinnamon::Remote リファクタ
- その他細かい修正
- これらの追加・修正にあわせてテストの追加と修正（既存のテストは出来る限り手を加えないように心がけたつもりですが...）。t/01_remote.tもテストが実施されるように修正してあります。

お時間のあるときに意見をいただけると幸いです。
