### PR TITLE
specify AnyEvent::Handle 'eol'

### DIFF
--- a/lib/Cinnamon/HandleManager.pm
+++ b/lib/Cinnamon/HandleManager.pm
@@ -36,7 +36,7 @@ sub start_async_read {
         my $handle; $handle = AnyEvent::Handle->new(
             fh => $info->{fh},
             on_read => sub {
-                $handle->push_read(line => sub {
+                $handle->push_read(line => qr|\r?\n|, sub {
                     my $line = $_[1];
                     push @{$info->{output_lines}}, $line;
                     log info => sprintf "[%s :: %s] %s",


### PR DESCRIPTION
can not handle '\r' correctly by default line detection in AnyEvent::Handle
cf. http://blog.1q77.com/2013/05/cinnamon-remote-cr/
