### PR TITLE
skip sudo password prompt for NOPASSWD sudoers

### DIFF
--- a/lib/Cinnamon/Context.pm
+++ b/lib/Cinnamon/Context.pm
@@ -228,7 +228,7 @@ sub dump_info {
 sub _get_sudo_password {
     my ($self) = @_;
     my $password = $self->get_param('password');
-    return $password if $password;
+    return $password if defined $password;
 
     print "Enter sudo password: ";
     ReadMode "noecho";


### PR DESCRIPTION
A sudo password prompt can be skipped if the user has NOPASSWD privilege, though current implementation always requires just pressing `Enter`.
